### PR TITLE
new Dockerfile for slimmed down version of lftools

### DIFF
--- a/lftools/Dockerfile.logs-publish
+++ b/lftools/Dockerfile.logs-publish
@@ -1,0 +1,22 @@
+#
+# Copyright (c) 2019
+# Intel
+#
+# This version of Docker image is being created to ONLY support lftools log
+# and archival publishing. Sigul signing is not supported with this image.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+FROM python:3-alpine
+
+LABEL license='SPDX-License-Identifier: Apache-2.0' \
+  copyright='Copyright (c) 2019: Intel' \
+  maintainer="Ernesto Ojeda <ernesto.ojeda@intel.com>"
+
+RUN apk add --update --no-cache \
+  build-base openssl-dev libffi-dev linux-headers xmlstarlet
+
+RUN pip3 install --no-cache-dir --upgrade pip setuptools \
+  && pip3 install --no-cache-dir -I lftools[openstack]==0.23.1 \
+  && apk del build-base linux-headers

--- a/lftools/Jenkinsfile
+++ b/lftools/Jenkinsfile
@@ -16,7 +16,8 @@
 
 loadGlobalLibrary()
 
-def image_amd64
+def image
+def logImage
 def changeDetected
 
 pipeline {
@@ -44,7 +45,8 @@ pipeline {
             when { expression { changeDetected } }
             steps {
                 script {
-                    image_amd64 = docker.build('edgex-lftools', '-f lftools/Dockerfile ./lftools')
+                    image = docker.build('edgex-lftools', '-f lftools/Dockerfile ./lftools')
+                    logImage = docker.build('edgex-lftools-log-publisher', '-f lftools/Dockerfile.logs-publish ./lftools')
                 }
             }
         }
@@ -54,9 +56,14 @@ pipeline {
             steps {
                 script {
                     docker.withRegistry("https://${env.DOCKER_REGISTRY}:10003") {
-                        image_amd64.push("latest")
-                        image_amd64.push(env.GIT_COMMIT)
-                        image_amd64.push("0.23.1-centos7")
+                        image.push("latest")
+                        image.push(env.GIT_COMMIT)
+                        image.push("0.23.1-centos7")
+                    }
+
+                    docker.withRegistry("https://${env.DOCKER_REGISTRY}:10003") {
+                        image.push("alpine")
+                        image.push("0.23.1-alpine")
                     }
                 }
             }


### PR DESCRIPTION
The image generated from this `Dockerfile.logs-publish` will be exclusively for using logs and archive publishing. This image is about 50% smaller than the centos7 based image.

Signed-off-by: Ernesto Ojeda <ernesto.ojeda@intel.com>