### PR TITLE
Added Clair scans to pipelines for various images

### DIFF
--- a/edgex-docs/Jenkinsfile
+++ b/edgex-docs/Jenkinsfile
@@ -107,6 +107,14 @@ pipeline {
                 }
             }
         }
+
+        stage('Clair Image Scan') {
+            when { expression { edgex.isReleaseStream() } }
+            steps {
+                edgeXClair("${env.DOCKER_REGISTRY}:10003/edgex-docs-builder:amd64")
+                edgeXClair("${env.DOCKER_REGISTRY}:10003/edgex-docs-builder:arm64")
+            }
+        }
     }
 
     post {

--- a/gcc/Jenkinsfile
+++ b/gcc/Jenkinsfile
@@ -25,6 +25,10 @@ pipeline {
         label 'centos7-docker-4c-2g'
     }
 
+    options {
+        timestamps()
+    }
+
     stages {
         stage('LF Prep') {
             steps {
@@ -98,6 +102,14 @@ pipeline {
                         }
                     }
                 }
+            }
+        }
+
+        stage('Clair Image Scan') {
+            when { expression { edgex.isReleaseStream() } }
+            steps {
+                edgeXClair("${env.DOCKER_REGISTRY}:10003/edgex-gcc-base:amd64")
+                edgeXClair("${env.DOCKER_REGISTRY}:10003/edgex-gcc-base:arm64")
             }
         }
     }

--- a/golang-1.12/Jenkinsfile
+++ b/golang-1.12/Jenkinsfile
@@ -25,6 +25,10 @@ pipeline {
         label 'centos7-docker-4c-2g'
     }
 
+    options {
+        timestamps()
+    }
+
     stages {
         stage('LF Prep') {
             steps {
@@ -98,6 +102,14 @@ pipeline {
                         }
                     }
                 }
+            }
+        }
+
+        stage('Clair Image Scan') {
+            when { expression { edgex.isReleaseStream() } }
+            steps {
+                edgeXClair("${env.DOCKER_REGISTRY}:10003/edgex-golang-base:amd64")
+                edgeXClair("${env.DOCKER_REGISTRY}:10003/edgex-golang-base:arm64")
             }
         }
     }

--- a/klar/Jenkinsfile
+++ b/klar/Jenkinsfile
@@ -24,6 +24,10 @@ pipeline {
         label 'centos7-docker-4c-2g'
     }
 
+    options {
+        timestamps()
+    }
+
     stages {
         stage('LF Prep') {
             steps {
@@ -60,6 +64,13 @@ pipeline {
                         }
                     }
                 }
+            }
+        }
+
+        stage('Clair Image Scan') {
+            when { expression { edgex.isReleaseStream() } }
+            steps {
+                edgeXClair("${env.DOCKER_REGISTRY}:10003/edgex-klar:latest")
             }
         }
     }

--- a/kong-arm-parent/Jenkinsfile
+++ b/kong-arm-parent/Jenkinsfile
@@ -24,6 +24,10 @@ pipeline {
         label 'centos7-docker-4c-2g'
     }
 
+    options {
+        timestamps()
+    }
+
     stages {
         stage('LF Prep') {
             steps {
@@ -57,6 +61,13 @@ pipeline {
                         image.push(env.BUILD_NUMBER)
                     }
                 }
+            }
+        }
+
+        stage('Clair Image Scan') {
+            when { expression { edgex.isReleaseStream() } }
+            steps {
+                edgeXClair("${env.DOCKER_REGISTRY}:10003/kong-arm-parent:latest")
             }
         }
     }

--- a/kong/Jenkinsfile
+++ b/kong/Jenkinsfile
@@ -24,6 +24,10 @@ pipeline {
         label 'centos7-docker-4c-2g'
     }
 
+    options {
+        timestamps()
+    }
+
     stages {
         stage('LF Prep') {
             steps {
@@ -57,6 +61,13 @@ pipeline {
                         image.push(env.BUILD_NUMBER)
                     }
                 }
+            }
+        }
+
+        stage('Clair Image Scan') {
+            when { expression { edgex.isReleaseStream() } }
+            steps {
+                edgeXClair("${env.DOCKER_REGISTRY}:10003/kong-arm:latest")
             }
         }
     }

--- a/lftools/Jenkinsfile
+++ b/lftools/Jenkinsfile
@@ -68,6 +68,14 @@ pipeline {
                 }
             }
         }
+
+        stage('Clair Image Scan') {
+            when { expression { edgex.isReleaseStream() } }
+            steps {
+                edgeXClair("${env.DOCKER_REGISTRY}:10003/edgex-lftools:0.23.1-centos7")
+                edgeXClair("${env.DOCKER_REGISTRY}:10003/edgex-lftools-log-publisher:0.23.1-alpine")
+            }
+        }
     }
 
     post {


### PR DESCRIPTION
- added Clair scan to edgex-docs
- added Clair scan to gcc
- added Clair scan to golang-1.12
- added Clair scan to klar
- added Clair scan to kong-arm-parent
- added Clair scan to kong
- added Clair scan to lftools
- added timestamps options to a few pipelines that were missing it (to maintain consistency)