### PR TITLE
updated lftools log publisher image to enable lftools sysinfo

### DIFF
--- a/lftools/Dockerfile.logs-publish
+++ b/lftools/Dockerfile.logs-publish
@@ -17,7 +17,17 @@ LABEL license='SPDX-License-Identifier: Apache-2.0' \
   maintainer="Ernesto Ojeda <ernesto.ojeda@intel.com>"
 
 RUN apk add --update --no-cache \
-  build-base openssl-dev libffi-dev linux-headers xmlstarlet bash git
+  build-base openssl-dev libffi-dev linux-headers xmlstarlet bash git util-linux
+
+# LF hosts run specific version of sysstat (sar) and lftools deploy logs
+# requires sysstat version to be same between container and host in order
+# for container to process sar reports on host
+RUN apkArch="$(apk --print-arch)"; \
+    case "$apkArch" in \
+        aarch64) apk add --no-cache sysstat ;; \
+        x86_64) apk add --no-cache --repository http://nl.alpinelinux.org/alpine/v2.6/main sysstat=10.1.5-r0 ;; \
+        *) echo >&2 "error: unsupported architecture ($apkArch)"; exit 1 ;; \
+    esac;
 
 RUN pip3 install --no-cache-dir --upgrade pip setuptools \
   && pip3 install --no-cache-dir -I lftools[openstack]==0.23.1 \

--- a/lftools/Jenkinsfile
+++ b/lftools/Jenkinsfile
@@ -61,7 +61,7 @@ pipeline {
                         }
 
                         stage('Docker Push') {
-                            when { expression { edgex.isReleaseStream() } }
+                            // when { expression { edgex.isReleaseStream() } }
                             steps {
                                 script {
                                     docker.withRegistry("https://${env.DOCKER_REGISTRY}:10003") {
@@ -71,10 +71,11 @@ pipeline {
                                     }
 
                                     docker.withRegistry("https://${env.DOCKER_REGISTRY}:10003") {
-                                        logImage_amd64.push("alpine")
-                                        logImage_amd64.push("0.23.1-alpine")
-                                        logImage_amd64.push("amd64")
-                                        logImage_amd64.push("x86_64")
+                                        // logImage_amd64.push("alpine")
+                                        // logImage_amd64.push("0.23.1-alpine")
+                                        // logImage_amd64.push("amd64")
+                                        // logImage_amd64.push("x86_64")
+                                        logImage_amd64.push("x86_64_bug459")
                                     }
                                 }
                             }
@@ -98,12 +99,13 @@ pipeline {
                         }
 
                         stage('Docker Push') {
-                            when { expression { edgex.isReleaseStream() } }
+                            // when { expression { edgex.isReleaseStream() } }
                             steps {
                                 script {
                                     docker.withRegistry("https://${env.DOCKER_REGISTRY}:10003") {
-                                        logImage_arm64.push("arm64")
-                                        logImage_arm64.push("aarch64")
+                                        // logImage_arm64.push("arm64")
+                                        // logImage_arm64.push("aarch64")
+                                        logImage_arm64.push("aarch64_bug459")
                                     }
                                 }
                             }


### PR DESCRIPTION
Updated lftools log publisher image with packages required in order for lftools to gather system information from the host.  Specifically added the following:
- systat package - required to make sar available in the image, note that the image version must match host version otherwise container is not able to read sar files from host. LF ARM64 and x64 agents have different versions of systat installed, thus included logic in the Dockerfile to facilitate the determination and installation of the proper sysstat version.
- util-linux package - required to make lscpu available in the image

This update is required to fix the following bug:
https://github.com/edgexfoundry/ci-management/issues/459

This includes updates required to build and push image with specific label to facilitate functional testing of bug.

**DO NOT MERGE!**

Signed-off-by: Emilio Reyes <emilio.reyes@intel.com>