### PR TITLE
Install tools required for LFtools deploy log

### DIFF
--- a/lftools/Dockerfile.logs-publish
+++ b/lftools/Dockerfile.logs-publish
@@ -17,7 +17,17 @@ LABEL license='SPDX-License-Identifier: Apache-2.0' \
   maintainer="Ernesto Ojeda <ernesto.ojeda@intel.com>"
 
 RUN apk add --update --no-cache \
-  build-base openssl-dev libffi-dev linux-headers xmlstarlet bash git
+  build-base openssl-dev libffi-dev linux-headers xmlstarlet bash git util-linux
+
+# LF hosts run specific version of sysstat (sar) and lftools deploy logs
+# requires sysstat version to be same between container and host in order
+# for container to process sar reports on host
+RUN apkArch="$(apk --print-arch)"; \
+    case "$apkArch" in \
+        aarch64) apk add --no-cache sysstat ;; \
+        x86_64) apk add --no-cache --repository http://nl.alpinelinux.org/alpine/v2.6/main sysstat=10.1.5-r0 ;; \
+        *) echo >&2 "error: unsupported architecture ($apkArch)"; exit 1 ;; \
+    esac;
 
 RUN pip3 install --no-cache-dir --upgrade pip setuptools \
   && pip3 install --no-cache-dir -I lftools[openstack]==0.23.1 \


### PR DESCRIPTION
Install tools required for LFtools deploy log

**Details:**
The LFtools deploy log script captures and appends system information to the _sys-info.log.gz file prior to pushing the log to Nexus. The system commands that LFtools executes when deploying logs are described here: https://github.com/lfit/releng-lftools/blob/master/lftools/deploy.py#L342
The commands include sar and lscpu, thus the packages that contain these tools need to be installed in the lftools logs publish image, namely sysstat and util-linux respectively.

The sar commands LFtools executes read the standard system activity file from the host, the caveat is that the version of sysstat between the host and the container **MUST** be the same.  Therefore logic was added to determine and install the proper version of sysstat in the Alpine-based lftools log publisher image.

LF leverages two build agents; one is x64-based (CentOS) and the other is arm64-based (Ubuntu), the version of sysstat installed in Ubuntu is consistent with the current sysstat version in the Alpine image. The version of sysstat that is installed in CentOS is an older version. We felt the *best* way to maintain a single Dockerfile was to leverage the architecture as the determining factor to what version of syssttat to install in the image.

This update in conjunction with https://github.com/edgexfoundry/ci-management/pull/462 resolves this issue https://github.com/edgexfoundry/ci-management/issues/459 
In summary, the pull request for ci-management makes the standard system activity file available to the lftools log publisher container, this pull request ensures the system tools are available in the lftools log publisher image.

**Note** due to the lack of exception handling with LFtools deploy logs, the pull request https://github.com/edgexfoundry/ci-management/pull/462  **MUST** be merged before this one. LFtools deploy logs has proper exception handling in the case where the system tools are not found, however it will throw an exception, fail and not deploy any logs if sar cannot open the standard system activity file. This was confirmed through testing in the Sandbox environment. 

**What was tested:**
Tested a sampling of jobs in the Sandbox environment which included:

- device-modbus-go-master-verify-go
- device-modbus-go-master-verify-go-arm
- docker-edgex-volume-master-verify-docker
- edgex-docs-master-verify-docs
- edgex-go-master-verify-go
- edgex-go-master-verify-go-arm
- edgex-go-snap-master-verify-snap
- edgex-ui-go-master-verify-go
- edgex-ui-go-master-verify-go-arm
- security-api-gateway-master-verify-go
- security-api-gateway-master-verify-go-arm
- support-rulesengine-master-verify-docker
- support-rulesengine-master-verify-docker-arm

**Test results:**
The following links shows system information being captured in the _sys-info.log.gz file:

- https://logs.edgexfoundry.org/sandbox/vex-yul-edgex-jenkins-2/edgex-go-master-verify-go/1/_sys-info.log.gz
- https://logs.edgexfoundry.org/sandbox/vex-yul-edgex-jenkins-2/edgex-ui-go-master-verify-go-arm/1/_sys-info.log.gz

@jamesrgregg @ernestojeda @lranjbar 

Signed-off-by: Emilio Reyes <emilio.reyes@intel.com>