### PR TITLE
Revert "Merge pull request #68 from soda480/cimgmt_bug459"

### DIFF
--- a/lftools/Dockerfile.logs-publish
+++ b/lftools/Dockerfile.logs-publish
@@ -17,17 +17,7 @@ LABEL license='SPDX-License-Identifier: Apache-2.0' \
   maintainer="Ernesto Ojeda <ernesto.ojeda@intel.com>"
 
 RUN apk add --update --no-cache \
-  build-base openssl-dev libffi-dev linux-headers xmlstarlet bash git util-linux
-
-# LF hosts run specific version of sysstat (sar) and lftools deploy logs
-# requires sysstat version to be same between container and host in order
-# for container to process sar reports on host
-RUN apkArch="$(apk --print-arch)"; \
-    case "$apkArch" in \
-        aarch64) apk add --no-cache sysstat ;; \
-        x86_64) apk add --no-cache --repository http://nl.alpinelinux.org/alpine/v2.6/main sysstat=10.1.5-r0 ;; \
-        *) echo >&2 "error: unsupported architecture ($apkArch)"; exit 1 ;; \
-    esac;
+  build-base openssl-dev libffi-dev linux-headers xmlstarlet bash git
 
 RUN pip3 install --no-cache-dir --upgrade pip setuptools \
   && pip3 install --no-cache-dir -I lftools[openstack]==0.23.1 \


### PR DESCRIPTION
This reverts commit cbd4f23366f03a907e48dc59b6fbf08a3253b439, reversing
changes made to 38718296232ca83768357a48367e7a0c647ca888.

This change should be reverted as it is breaking all pipeline jobs.  To fix the pipeline jobs the edgeXInfraPublish global library needs to be updated to determine and mount the host systems activity file in the container.  Since this will require additional testing in Sandbox, the best approach forward will be to revert the previous pull request to give us the time to make the changes needed and thoroughly test this in Sandbox.

Signed-off-by: Emilio Reyes <emilio.reyes@intel.com>