### PR TITLE
Add edgex-taf docker image build job

### DIFF
--- a/edgex-taf/Jenkinsfile
+++ b/edgex-taf/Jenkinsfile
@@ -1,0 +1,133 @@
+//
+// Copyright (c) 2019 Intel Corporation
+// Copyright (c) 2019 IOTech Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+loadGlobalLibrary()
+
+def image_amd64
+def image_arm64
+def changeDetected
+
+pipeline {
+    agent {
+        label 'centos7-docker-4c-2g'
+    }
+
+    options {
+        timestamps()
+    }
+
+    stages {
+        stage('LF Prep') {
+            steps {
+                edgeXSetupEnvironment()
+                script {
+                    changeDetected = edgex.didChange('edgex-taf')
+                    println "Detected Change in edgex-taf? ${changeDetected}"
+                }
+            }
+        }
+
+        stage('Build Docker Image') {
+            when { expression { changeDetected } }
+            parallel {
+                stage('amd64') {
+                    agent {
+                        label 'centos7-docker-4c-2g'
+                    }
+                    stages {
+                        stage('Docker Build') {
+                            steps {
+                                edgeXDockerLogin(settingsFile: env.MVN_SETTINGS)
+
+                                sh "git clone git@github.com:edgexfoundry-holding/edgex-taf-common.git"
+                                script {
+                                    image_amd64 = docker.build('edgex-taf', '-f edgex-taf-common/Dockerfile edgex-taf-common')
+                                }
+                            }
+                        }
+
+                        stage('Docker Push') {
+                            when { expression { edgex.isReleaseStream() } }
+                            steps {
+                                script {
+                                    docker.withRegistry("https://${env.DOCKER_REGISTRY}:10003") {
+                                        image_amd64.push("amd64")
+                                        image_amd64.push(env.GIT_COMMIT)
+                                        image_amd64.push("1.11.9-alpine")
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
+                stage('arm64') {
+                    agent {
+                        label 'ubuntu18.04-docker-arm64-4c-2g'
+                    }
+                    stages {
+                        stage('Docker Build') {
+                            steps {
+                                edgeXDockerLogin(settingsFile: env.MVN_SETTINGS)
+
+                                sh "git clone git@github.com:edgexfoundry-holding/edgex-taf-common.git"
+                                script {
+                                    image_arm64 = docker.build('edgex-taf', '-f edgex-taf-common/Dockerfile edgex-taf-common')
+                                }
+                            }
+                        }
+
+                        stage('Docker Push') {
+                            when { expression { edgex.isReleaseStream() } }
+                            steps {
+                                script {
+                                    docker.withRegistry("https://${env.DOCKER_REGISTRY}:10003") {
+                                        image_arm64.push("arm64")
+                                        image_arm64.push("${env.GIT_COMMIT}-arm64")
+                                        image_arm64.push("1.11.9-alpine-arm64")
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+    }
+
+    post {
+        always {
+            edgeXInfraPublish()
+        }
+    }
+}
+
+def loadGlobalLibrary(branch = '*/master') {
+    library(identifier: 'edgex-global-pipelines@master', 
+        retriever: legacySCM([
+            $class: 'GitSCM',
+            userRemoteConfigs: [[url: 'https://github.com/edgexfoundry/edgex-global-pipelines.git']],
+            branches: [[name: branch]],
+            doGenerateSubmoduleConfigurations: false,
+            extensions: [[
+                $class: 'SubmoduleOption',
+                recursiveSubmodules: true,
+            ]]]
+        )
+    ) _
+}


### PR DESCRIPTION
Fix #74
This PR is used to create an edgex-taf docker image which can trigger automation tests, it should work after [edgex-taf-common PR](https://github.com/edgexfoundry-holding/edgex-taf-common/pull/5) merged.