### PR TITLE
Build compose image with binaries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,54 +1,16 @@
-ARG DOCKER_VERSION=19.03.5
-ARG PYTHON_VERSION=3.7.5
-ARG BUILD_ALPINE_VERSION=3.10
-ARG RUNTIME_ALPINE_VERSION=3.10.3
-ARG COMPOSE_TAG=1.25.4
+FROM alpine:3.11
+# https://docs.docker.com/compose/install/#install-compose-on-linux-systems
+RUN apk add --update --no-cache \
+  docker-compose \
+  py-pip \
+  python-dev \
+  libffi-dev \
+  openssl-dev \
+  gcc \
+  libc-dev \
+  make \
+  unzip \
+  bash \
+  curl
 
-FROM docker:${DOCKER_VERSION} AS docker-cli
-
-FROM python:${PYTHON_VERSION}-alpine${BUILD_ALPINE_VERSION} AS build
-
-RUN apk add --no-cache \
-    bash \
-    build-base \
-    ca-certificates \
-    curl \
-    gcc \
-    git \
-    libc-dev \
-    libffi-dev \
-    libgcc \
-    make \
-    musl-dev \
-    openssl \
-    openssl-dev \
-    python2 \
-    python2-dev \
-    zlib-dev
-ENV BUILD_BOOTLOADER=1
-
-COPY --from=docker-cli /usr/local/bin/docker /usr/local/bin/docker
-
-WORKDIR /code/
-
-ARG COMPOSE_TAG
-RUN git clone --branch ${COMPOSE_TAG} --quiet --recurse-submodules https://github.com/docker/compose.git .
-
-# FIXME(chris-crone): virtualenv 16.3.0 breaks build, force 16.2.0 until fixed
-RUN pip install virtualenv==16.2.0
-RUN pip install tox==2.9.1
-
-RUN tox --notest
-ARG GIT_COMMIT=unknown
-ENV DOCKER_COMPOSE_GITSHA=$GIT_COMMIT
-RUN script/build/linux-entrypoint
-RUN cp docker-compose-entrypoint.sh /usr/local/bin/
-ENTRYPOINT ["sh", "/usr/local/bin/docker-compose-entrypoint.sh"]
-
-FROM alpine:${RUNTIME_ALPINE_VERSION} AS runtime
-ARG COMPOSE_TAG
-RUN wget https://raw.githubusercontent.com/docker/compose/${COMPOSE_TAG}/docker-compose-entrypoint.sh
-RUN cp docker-compose-entrypoint.sh /usr/local/bin/
-ENTRYPOINT ["sh", "/usr/local/bin/docker-compose-entrypoint.sh"]
-COPY --from=docker-cli  /usr/local/bin/docker           /usr/local/bin/docker
-COPY --from=build       /usr/local/bin/docker-compose   /usr/local/bin/docker-compose
+ENTRYPOINT ["/usr/bin/docker-compose"]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,6 +20,6 @@ edgeXBuildDocker ([
     dockerImageName: 'edgex-compose',
     dockerNamespace: 'edgex-devops',
     dockerNexusRepo: 'snapshots',
-    dockerTags: ["1.25.4"],
+    dockerTags: ["1.24.1"],
     releaseBranchOverride: 'edgex-compose'
 ])


### PR DESCRIPTION
Signed-off-by: Cherry Wang <cherry@iotechsys.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/edgexfoundry/ci-management/blob/master/.github/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Added labels
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Issue Number:
closes #134
## Sandbox Testing
Test Links :


## Are there any specific instructions or things that should be known prior to reviewing?
Currently, build docker-compose using [compose repository](https://github.com/docker/compose/tree/1.25.4) always got failure.
Change the way to use @ernestojeda's suggestion on PR #120 to build compose image. 

## Other information
