### PR TITLE
update for new snapcraft, fix old bugs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,5 +20,7 @@ edgeXBuildDocker (
     dockerImageName: 'edgex-snap-builder',
     dockerNamespace: 'edgex-devops',
     dockerNexusRepo: 'snapshots',
+    dockerPushLatest: false,
+    dockerTags: ['new-snap-updates'],
     releaseBranchOverride: 'snapcraft-builder'
 )

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -19,29 +19,29 @@ case "$JOB_TYPE" in
     "stage")
         # Stage jobs build the snap locally and release it
         pushd /build > /dev/null
-        snapcraft clean
-        snapcraft
+        unbuffer snapcraft clean
+        unbuffer snapcraft
         popd > /dev/null
         pushd /build > /dev/null
-        snapcraft login --with /build/edgex-snap-store-login
+        unbuffer snapcraft login --with /build/edgex-snap-store-login
         # Push the snap up to the store and release it on the specified
         # channel
-        snapcraft push "$SNAP_NAME"*.snap --release "$SNAP_CHANNEL" 
+        unbuffer snapcraft push "$SNAP_NAME"*.snap --release "$SNAP_CHANNEL" 
         # Also force an update of the meta-data
-        snapcraft push-metadata "$SNAP_NAME"*.snap --force
+        unbuffer snapcraft push-metadata "$SNAP_NAME"*.snap --force
         popd > /dev/null
     ;;
     "release")
         # Release jobs will promote an already built snap revision
         # in the store to a channel.
-        snapcraft login --with /build/edgex-snap-store-login
-        snapcraft release "$SNAP_NAME" "$SNAP_REVISION" "$SNAP_CHANNEL"
+        unbuffer snapcraft login --with /build/edgex-snap-store-login
+        unbuffer snapcraft release "$SNAP_NAME" "$SNAP_REVISION" "$SNAP_CHANNEL"
     ;;
     *)
         # Do normal build and nothing else to verify the snap builds
         pushd /build > /dev/null
-        snapcraft clean
-        snapcraft
+        unbuffer snapcraft clean
+        unbuffer snapcraft
         popd > /dev/null
     ;;
 esac


### PR DESCRIPTION
Migrated from ci-management: https://github.com/edgexfoundry/ci-management/pull/617
Changes by Ian Johnson <ian.johnson@canonical.com>

Due to some libraries that snapcraft/python use for outputting, the ordering of
some output gets lost when it is piped through docker. To fix this we can just
run snapcraft through unbuffer, which is provided through the expect package.

This is needed because now snapcraft will use "snap pack" from the host, and so
we need the snap command in the docker container alongside the snapcraft snap.

The previous behavior would not actually fail the build setup if for example the
SHA's didn't match, but now if the SHA's don't match, sha512sum will exit
non-zero and using && results in the whole command failing.

We also should delete the sha512 file as well, it is not needed during the
build.

Fixes: #517

Signed-off-by: Ernesto Ojeda <ernesto.ojeda@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/edgexfoundry/ci-management/blob/master/.github/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Added labels
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Issue Number:

## Sandbox Testing
Test Links :

## Are there any new imports or modules? If so, what are they used for and why?


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information
