### PR TITLE
optimize edgex-docs image to only install raml2html

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,29 +1,17 @@
 #
-# Copyright (c) 2019
+# Copyright (c) 2020
 # Intel
 #
 # SPDX-License-Identifier: Apache-2.0
 # 
-# Migrated from https://github.com/edgexfoundry/edgex-docs/blob/master/Dockerfile.build
 #
-FROM ubuntu:16.04
+FROM node:lts-alpine
 
 LABEL license='SPDX-License-Identifier: Apache-2.0' \
   copyright='Copyright (c) 2019: Intel' \
   maintainer='EdgeX Foundry <edgex-devel@lists.edgexfoundry.org>'
 
-RUN apt-get update && apt-get dist-upgrade -y && \
-  apt-get install -y git python-pip nodejs npm \
-  make linkchecker wget curl
-RUN apt-get install -y --no-install-recommends \
-  latexmk texlive-latex-recommended \
-  texlive-latex-extra texlive-fonts-recommended \
-  && rm -rf /usr/share/doc/*
-RUN ln -s /usr/bin/nodejs /usr/bin/node
-RUN pip install sphinx==1.7.9 sphinxcontrib-googleanalytics==0.1
-RUN npm i -g raml2html@3.0.1
+RUN yarn global add --silent raml2html@3.0.1 \
+  && yarn cache clean --silent
 
 COPY ./scripts/raml-verify.sh /scripts/
-
-RUN mkdir docbuild
-WORKDIR /docbuild


### PR DESCRIPTION
Now that edgex-docs uses mkdocs to build HTML documentation from markdown, this image is only really used in edgex-go in the `raml_verify` make target to verify raml files are correct. This PR reduces the docker image from 845MB to 111MB. This will help speed up the test stage in the new edgex-go pipeline.

Signed-off-by: Ernesto Ojeda <ernesto.ojeda@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/edgexfoundry/ci-management/blob/master/.github/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Added labels
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Issue Number:

## Sandbox Testing
Test Links :

## Are there any new imports or modules? If so, what are they used for and why?


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information
