### PR TITLE
feat: replace BusyBox mktemp with GNU mktemp

### DIFF
--- a/Dockerfile.logs-publish
+++ b/Dockerfile.logs-publish
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019
+# Copyright (c) 2020
 # Intel
 #
 # This version of Docker image is being created to ONLY support lftools log
@@ -8,32 +8,49 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-FROM python:3-alpine
+# Build gnumktemp in favor of busybox mktemp
+FROM alpine:3.12 as mktempbuilder
+WORKDIR /tmp/build
+RUN apk add --update --no-cache build-base linux-headers
+RUN wget https://www.mktemp.org/dist/mktemp-1.7.tar.gz \
+  && tar -xzvf mktemp-1.7.tar.gz \
+  && cd mktemp-1.7 \
+  && wget "http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD" -O config.guess \
+  && wget "http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;hb=HEAD" -O config.sub \
+  && ./configure \
+  && make install
 
-ARG GLOBAL_JJB_COMMIT=a47a2c5d2839a34e22c67e9e1e6578efd5540ae2
+FROM python:3.6-alpine
+
+# updating to match EGP v0.55.2
+ARG GLOBAL_JJB_COMMIT=64faafae2362d36e4d5c3e8d5fe6579b9d09cf55
 
 LABEL license='SPDX-License-Identifier: Apache-2.0' \
-  copyright='Copyright (c) 2019: Intel' \
+  copyright='Copyright (c) 2020: Intel' \
   maintainer="Ernesto Ojeda <ernesto.ojeda@intel.com>"
 
-RUN apk add --update --no-cache \
-  build-base openssl-dev libxml2-dev libxslt-dev libffi-dev linux-headers xmlstarlet bash git util-linux
+RUN mv /bin/mktemp /bin/mktemp-busybox
+COPY --from=mktempbuilder /usr/local/bin/mktemp /usr/local/bin/mktemp
 
-# LF hosts run specific version of sysstat (sar) and lftools deploy logs
+# Currently a python issue with setuptools, this is a workaround
+# https://github.com/pypa/setuptools/issues/2355
+ENV SETUPTOOLS_USE_DISTUTILS="stdlib"
+
+# LF hosts run specific version of sysstat (sar) and `lftools deploy logs`
 # requires sysstat version to be same between container and host in order
-# for container to process sar reports on host
-RUN apkArch="$(apk --print-arch)"; \
-    case "$apkArch" in \
-        aarch64) apk add --no-cache sysstat ;; \
-        x86_64) apk add --no-cache --repository http://nl.alpinelinux.org/alpine/v2.6/main sysstat=10.1.5-r0 ;; \
-        *) echo >&2 "error: unsupported architecture ($apkArch)"; exit 1 ;; \
-    esac;
+# for container to process sar reports on host. However, there is a technique
+# we can use with sadf to convert between different versions of sar formats.
+# See: https://serverfault.com/questions/757771/how-to-read-sar-file-from-different-ubuntu-system
+RUN apk add --update --no-cache \
+  build-base openssl-dev libxml2-dev \
+  libxslt-dev libffi-dev linux-headers \
+  xmlstarlet bash git util-linux sysstat \
 
-RUN pip3 install --no-cache-dir --upgrade pip setuptools \
+  && pip3 install --no-cache-dir --upgrade pip setuptools \
   && pip3 install --no-cache-dir -I lftools[openstack]==0.31.1 \
-  && apk del build-base linux-headers
 
-RUN git clone https://github.com/lfit/releng-global-jjb.git global-jjb
-RUN cd global-jjb \
+  && git clone https://github.com/lfit/releng-global-jjb.git global-jjb \
+  && cd global-jjb \
   && git reset --hard ${GLOBAL_JJB_COMMIT} \
-  && apk del git
+
+  && apk del git build-base linux-headers


### PR DESCRIPTION
I am creating this PR to add support this PR: https://github.com/edgexfoundry/edgex-global-pipelines/pull/228

Added a multi stage docker file to build GNU mktemp from source and grouped all the RUN commands into a single layer to reduce image size.
Image size:
- before: 412MB
- after: 122MB

**Note:**
In the process of attempting to rebuild this image, it seems that alpine v2.6 is no longer available anywhere so I had to upgrade sysstat to a newer version. I know the version mismatch between the host and docker container causes issues. However, I found sar files can be converted to different version formats. I have documented this in the Dockerfile.logs-publish.

Signed-off-by: Ernesto Ojeda <ernesto.ojeda@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/edgexfoundry/ci-management/blob/master/.github/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Added labels
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Issue Number:

## Sandbox Testing

Sysstat Conversion Technique:
Convert from 10.1.5 to 12.2.1
https://jenkins.edgexfoundry.org/sandbox/view/All/job/Functional-Testing/job/sysstat-version/14/console

## Are there any new imports or modules? If so, what are they used for and why?


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information
