### PR TITLE
downgrade to 1.410.4 due to snyk test with dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ LABEL license='SPDX-License-Identifier: Apache-2.0' \
 
 RUN sed -e 's/dl-cdn[.]alpinelinux.org/nl.alpinelinux.org/g' -i~ /etc/apk/repositories
 
-ARG SNYK_VERSION=1.419.1
+ARG SNYK_VERSION=1.410.4
 ENV SNYK_VERSION=${SNYK_VERSION}
 
 COPY --from=docker:latest /usr/local/bin/docker /usr/local/bin/docker

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,6 +21,6 @@ edgeXBuildDocker (
     dockerImageName: 'edgex-snyk-go',
     dockerNamespace: 'edgex-devops',
     dockerNexusRepo: 'snapshots',
-    dockerTags: ["1.419.1"],
+    dockerTags: ["1.410.4"],
     releaseBranchOverride: 'snyk'
 )


### PR DESCRIPTION
Downgrading due to issues with weird issue with current version `1.419.1`. Testing with 1.410.4 everything works as expected.

```
# v1.419.1
snyk test --docker nexus3.edgexfoundry.org:10004/docker-security-proxy-setup-go:master '--file=Dockerfile' '--severity-threshold=high'
Authentication failed. Please check the API token on https://snyk.io
```

`--file=Dockerfile` causes this authentication failed issue. Removing the `--file` the command works fine:

```
# v1.419.1
snyk test --docker nexus3.edgexfoundry.org:10004/docker-security-proxy-setup-go:master '--severity-threshold=high'
...
✓ Tested 18 dependencies for known issues, no vulnerable paths found.
```


Signed-off-by: Ernesto Ojeda <ernesto.ojeda@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/edgexfoundry/ci-management/blob/master/.github/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Added labels
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Issue Number:

## Sandbox Testing
Test Links :

## Are there any new imports or modules? If so, what are they used for and why?


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information
